### PR TITLE
Update CLAUDE.md to reflect docs/demos structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ internal/
   generate/         # OpenAPI to Accord contract generation
   openapi/          # OpenAPI spec parsing
 docs/               # Getting started guide, CLI reference
+  demos/            # Executable showboat demo documents
 testdata/           # Valid and invalid contract fixtures
 ```
 


### PR DESCRIPTION
Adds `docs/demos/` to the file structure section.